### PR TITLE
Improved custom provider implementation, and support for dynamic objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Or get a list of objects:
 
     var cars = context.All<Car>("SELECT * FROM Cars");
 
+Or, load into a dynamic object. Each field name in the data source will be added dynamically:
+
+	dynamic car = context.First<ExpandoObject>("SELECT Name, CreatedAt as CreatedOn FROM Car");
+	IEnumerable<dynamic> cars = context.All<ExpandoObject>("SELECT * FROM Car");
+
 Parameters binding works likewise:
 
     context.All<Car>("SELECT * FROM Cars WHERE Name LIKE %@0%", "Lotus");

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Thunderstruck
 =============
 
-Thunderstruck is a .NET library that makes access to database simpler and faster using ADO.NET. A really fast way to access databases.
+Thunderstruck is a .NET library that makes access to databases simpler and faster using ADO.NET. A really fast way to access databases.
 
 Another ORM?
 ------------
 
-No! Thunderstruck isn't an ORM. It doesn't abstract the features of the database, just makes the access easier.
+No! Thunderstruck isn't an ORM. It doesn't abstract the features of the database, just makes accessing the database easier.
 
 Install
 -------
@@ -30,7 +30,7 @@ Executes a transactional SQL command with the DataContext:
         context.Commit();
     }
 
-Executes a non transactional command:
+Executes a non-transactional command:
 
     using (var context = new DataContext(Transaction.No))
     {
@@ -38,11 +38,11 @@ Executes a non transactional command:
         context.Execute("DELETE FROM Tools");
     }
 
-DataContext uses the Connection String named "Default" in Application.config (or Web.config):
+DataContext uses the Connection String named "Default" in App.config (or Web.config):
 
     <add name="Default" providerName="..." connectionString="..." />
 
-If you need a different configuration, you can say to the DataContext what's the ConnectionString name to use:
+If you need a different default connection string, you can specify the DefaultConnectionString name to use on the DataContext class:
 
     DataContext.DefaultConnectionStringName = "AnotherDefaultConnection";
 
@@ -60,25 +60,25 @@ You can use any object to bind:
 
     context.Execute("INSERT INTO Dates VALUES (@Year, @Month, @Day)", DateTime.Today);
 
-Or you can use an params array to bind values:
+Or you can use a params array to bind values:
 
     context.Execute("INSERT INTO Dates VALUES (@0, @1, @2)", 2005, 3, 31);
 
 ### DataContext — Reading
 
-Read a value from database is simple with Thunderstruck:
+Reading a value from the database is simple with Thunderstruck:
 
     var carsCount = context.GetValue("SELECT COUNT(Id) From Cars");
 
-Or use a typed read to cast the value of the reading:
+Or specify the type to cast the value to when reading:
 
     var last = context.GetValue<DateTime>("SELECT MAX(CreatedAt) From Cars");
 
-Or take a list of objects:
+Or get a list of values:
 
     var carNames = context.GetValues<string>("SELECT Name FROM Cars")
 
-Read data from database and fill it to object:
+Read data from the database and fill it to object:
 
     var car = context.First<Car>("SELECT TOP 1 Id, Name, ModelYear, Category FROM Cars");
 
@@ -87,7 +87,7 @@ Read data from database and fill it to object:
     car.ModelYear // 1980
     car.Category // CarCategory.Sport (enum!)
 
-Or a list of objects:
+Or get a list of objects:
 
     var cars = context.All<Car>("SELECT * FROM Cars");
 
@@ -95,7 +95,7 @@ Parameters binding works likewise:
 
     context.All<Car>("SELECT * FROM Cars WHERE Name LIKE %@0%", "Lotus");
 
-You can call procedures with Thunderstruck:
+You can call stored procedures with Thunderstruck:
 
     var whoResults = context.All<WhoResult>("EXEC sp_who @0", "active");
 
@@ -107,7 +107,7 @@ Thunderstruck supports SQL Server, Oracle and MySQL with these providers name:
     System.Data.OracleClient
     MySql.Data.MySqlClient
 
-But is easy to create a custom provider, less than 50 lines ([extending DefaultProvider][sql-provider-link]), and set it in Thunderstruck:
+It is easy to create a custom provider, usually less than 50 lines of code ([extending DefaultProvider][sql-provider-link]), and set it in Thunderstruck:
 
     ProviderFactory.CustomProvider = (providerName) => new MyCustomProvider();
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,15 @@ Thunderstruck supports SQL Server, Oracle and MySQL with these providers name:
     System.Data.OracleClient
     MySql.Data.MySqlClient
 
-It is easy to create a custom provider, usually less than 50 lines of code ([extending DefaultProvider][sql-provider-link]), and set it in Thunderstruck:
+It is easy to create a custom provider, usually less than 50 lines of code ([extending DefaultProvider][sql-provider-link]).
 
-    ProviderFactory.CustomProvider = (providerName) => new MyCustomProvider();
+There are two ways to add a custom provider:
+
+1. Add it as an additional provider: ProviderFactory.AddProvider("My.Provider", typeof(MyProvider))
+2. Add it as a custom provider: ProviderFactory.CustomProvider = (providerName) => new MyCustomProvider();
+
+Note, when you set a CustomProvider, that is the only provider available to Thunderbird! If you want to use multiple
+providers, use the AddProvider() method.
 
 ### DataObject
 

--- a/Thunderstruck.Test/Functional/SqlTest.cs
+++ b/Thunderstruck.Test/Functional/SqlTest.cs
@@ -5,346 +5,359 @@ using Thunderstruck.Test.Models;
 using System.Linq;
 using System.Data.SqlClient;
 using Thunderstruck.Provider;
+using System.Dynamic;
 
 namespace Thunderstruck.Test.Functional
 {
-    [TestClass]
-    public class SqlTest
-    {
-        private static SqlEnvironment environment;
-        private DataObject<Car> carDataObject;
-        private DataObject<Manufacturer> manufacturerDataObject;
+	[TestClass]
+	public class SqlTest
+	{
+		private static SqlEnvironment environment;
+		private DataObject<Car> carDataObject;
+		private DataObject<Manufacturer> manufacturerDataObject;
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext tests)
-        {
-            environment = new SqlEnvironment();
-        }
+		[ClassInitialize]
+		public static void ClassInitialize(TestContext tests)
+		{
+			environment = new SqlEnvironment();
+		}
 
-        [TestInitialize]
-        public void Initialize()
-        {
-            carDataObject = new DataObject<Car>();
-            manufacturerDataObject = new DataObject<Manufacturer>(table: "Le_Manufacturer", primaryKey: "TheId");
+		[TestInitialize]
+		public void Initialize()
+		{
+			carDataObject = new DataObject<Car>();
+			manufacturerDataObject = new DataObject<Manufacturer>(table: "Le_Manufacturer", primaryKey: "TheId");
 
-            ProviderFactory.CustomProvider = null;
-            ProviderFactory.ConnectionFactory = null;
-        }
+			ProviderFactory.CustomProvider = null;
+			ProviderFactory.ConnectionFactory = null;
+		}
 
-        [TestMethod]
-        public void A_DataContext_Transitional_Should_Execute_A_Insert_SQL_Command_With_Anonymous_Object_Parameters_And_Read_Created_Data_In_Same_And_Count_Data_In_Another_Context()
-        {
-            using (var context = new DataContext())
-            {
-                var insertParameters = new { Name = "Lotus", Year = 1952 };
-                context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
-                var manufacturer = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer");
-                context.Commit();
+		[TestMethod]
+		public void A_DataContext_Transitional_Should_Execute_A_Insert_SQL_Command_With_Anonymous_Object_Parameters_And_Read_Created_Data_In_Same_And_Count_Data_In_Another_Context()
+		{
+			using (var context = new DataContext())
+			{
+				var insertParameters = new { Name = "Lotus", Year = 1952 };
+				context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
+				var manufacturer = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer");
+				context.Commit();
 
-                manufacturer.TheId.Should().BeGreaterThan(0);
-                manufacturer.Name.Should().Be("Lotus");
-                manufacturer.BuildYear.Should().Be(1952);
-            }
+				manufacturer.TheId.Should().BeGreaterThan(0);
+				manufacturer.Name.Should().Be("Lotus");
+				manufacturer.BuildYear.Should().Be(1952);
+			}
 
-            using (var context = new DataContext())
-            {
-                var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
+			using (var context = new DataContext())
+			{
+				var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
 
-                manufacturerCount.Should().Be(1);
-            }
-        }
+				manufacturerCount.Should().Be(1);
+			}
+		}
 
-        [TestMethod]
-        public void B_DataContext_Transitional_Should_Execute_A_Insert_SQL_Command_With_Array_Parameters_And_Read_Created_Data_In_Same_And_Count_Data_In_Another_Context()
-        {
-            using (var context = new DataContext())
-            {
-                context.Execute("INSERT INTO Le_Manufacturer VALUES (@0, @1)", "McLaren", 1963);
-                var manufacturer = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer WHERE Name = @0", "McLaren");
-                context.Commit();
+		[TestMethod]
+		public void B_DataContext_Transitional_Should_Execute_A_Insert_SQL_Command_With_Array_Parameters_And_Read_Created_Data_In_Same_And_Count_Data_In_Another_Context()
+		{
+			using (var context = new DataContext())
+			{
+				context.Execute("INSERT INTO Le_Manufacturer VALUES (@0, @1)", "McLaren", 1963);
+				var manufacturer = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer WHERE Name = @0", "McLaren");
+				context.Commit();
 
-                manufacturer.TheId.Should().BeGreaterThan(0);
-                manufacturer.Name.Should().Be("McLaren");
-                manufacturer.BuildYear.Should().Be(1963);
-            }
+				manufacturer.TheId.Should().BeGreaterThan(0);
+				manufacturer.Name.Should().Be("McLaren");
+				manufacturer.BuildYear.Should().Be(1963);
+			}
 
-            using (var context = new DataContext())
-            {
-                var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
+			using (var context = new DataContext())
+			{
+				var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
 
-                manufacturerCount.Should().Be(2);
-            }
-        }
+				manufacturerCount.Should().Be(2);
+			}
+		}
 
-        [TestMethod]
-        public void C_DataContext_Non_Transitional_Should_Execute_A_Insert_SQL_Command_With_Object_Parameters_And_Read_Created_Data_In_Same_And_Count_Data()
-        {
-            using (var context = new DataContext(Transaction.No))
-            {
-                var insertParameters = new Manufacturer { Name = "General Motors", BuildYear = 1908 };
-                context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @BuildYear)", insertParameters);
-                var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE BuildYear = 1908");
-                var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
+		[TestMethod]
+		public void C_DataContext_Non_Transitional_Should_Execute_A_Insert_SQL_Command_With_Object_Parameters_And_Read_Created_Data_In_Same_And_Count_Data()
+		{
+			using (var context = new DataContext(Transaction.No))
+			{
+				var insertParameters = new Manufacturer { Name = "General Motors", BuildYear = 1908 };
+				context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @BuildYear)", insertParameters);
+				var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE BuildYear = 1908");
+				var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
 
-                manufacturer.TheId.Should().BeGreaterThan(0);
-                manufacturer.Name.Should().Be("General Motors");
-                manufacturer.BuildYear.Should().Be(1908);
-                manufacturerCount.Should().Be(3);
-            }
-        }
+				manufacturer.TheId.Should().BeGreaterThan(0);
+				manufacturer.Name.Should().Be("General Motors");
+				manufacturer.BuildYear.Should().Be(1908);
+				manufacturerCount.Should().Be(3);
+			}
+		}
 
-        [TestMethod]
-        public void D_DataContext_Transitional_Should_Not_Commit_Data_If_Not_Explicit_Commit_Command_Call()
-        {
-            using (var context = new DataContext())
-            {
-                var insertParameters = new { Name = "Bentley", Year = 1919 };
-                context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
-            }
+		[TestMethod]
+		public void D_DataContext_Transitional_Should_Not_Commit_Data_If_Not_Explicit_Commit_Command_Call()
+		{
+			using (var context = new DataContext())
+			{
+				var insertParameters = new { Name = "Bentley", Year = 1919 };
+				context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
+			}
 
-            using (var context = new DataContext())
-            {
-                var manufacturers = context.All<Manufacturer>("SELECT * FROM Le_Manufacturer");
+			using (var context = new DataContext())
+			{
+				var manufacturers = context.All<Manufacturer>("SELECT * FROM Le_Manufacturer");
 
-                manufacturers.Count().Should().Be(3);
-                manufacturers.Should().Contain(m => m.Name == "Lotus");
-                manufacturers.Should().Contain(m => m.Name == "General Motors");
-            }
-        }
+				manufacturers.Count().Should().Be(3);
+				manufacturers.Should().Contain(m => m.Name == "Lotus");
+				manufacturers.Should().Contain(m => m.Name == "General Motors");
+			}
+		}
 
-        [TestMethod]
-        public void E_DataContext_Transitional_Should_Execute_A_SQL_And_Share_Transaction_With_A_Data_Reader()
-        {
-            using (var context = new DataContext())
-            {
-                var insertParameters = new { Name = "BMW", Year = 1916 };
-                context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
-                var selectParameters = new { Name = "BMW" };
-                var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
+		[TestMethod]
+		public void E_DataContext_Transitional_Should_Execute_A_SQL_And_Share_Transaction_With_A_Data_Reader()
+		{
+			using (var context = new DataContext())
+			{
+				var insertParameters = new { Name = "BMW", Year = 1916 };
+				context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
+				var selectParameters = new { Name = "BMW" };
+				var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
 
-                manufacturer.Should().NotBeNull();
-            }
+				manufacturer.Should().NotBeNull();
+			}
 
-            using (var context = new DataContext())
-            {
-                var selectParameters = new { Name = "BMW" };
-                var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
+			using (var context = new DataContext())
+			{
+				var selectParameters = new { Name = "BMW" };
+				var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
 
-                manufacturer.Should().BeNull();
-            }
-        }
+				manufacturer.Should().BeNull();
+			}
+		}
 
-        [TestMethod]
-        public void F_DataContext_Should_Read_Data_With_One_Field_And_Insert_A_Data_With_Some_Parameters_Types()
-        {
-            using (var context = new DataContext())
-            {
-                var selectParameters = new { Name = "Lotus" };
-                var manufacturer = context.First<Manufacturer>("SELECT TheId FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
-                
-                var insertParameters = new Car
-                {
-                    Name = "Esprit Turbo",
-                    ModelYear = 1981,
-                    Mileage = 318.19850801,
-                    ManufacturerId = manufacturer.TheId,
-                    Category = CarCategory.Sport
-                };
+		[TestMethod]
+		public void F_DataContext_Should_Read_Data_With_One_Field_And_Insert_A_Data_With_Some_Parameters_Types()
+		{
+			using (var context = new DataContext())
+			{
+				var selectParameters = new { Name = "Lotus" };
+				var manufacturer = context.First<Manufacturer>("SELECT TheId FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
 
-                context.Execute("INSERT INTO Car VALUES (@Name, @ModelYear, @CreatedAt, @Chassis, @Mileage, @Category, @ManufacturerId)", insertParameters);
-                var car = context.First<Car>("SELECT TOP 1 * FROM Car");
-                context.Commit();
+				var insertParameters = new Car
+				{
+					Name = "Esprit Turbo",
+					ModelYear = 1981,
+					Mileage = 318.19850801,
+					ManufacturerId = manufacturer.TheId,
+					Category = CarCategory.Sport
+				};
 
-                car.Id.Should().BeGreaterThan(0);
-                car.Name.Should().Be("Esprit Turbo");
-                car.ModelYear.Should().Be(1981);
-                car.Mileage.Should().Be(318.19850801);
-                car.ManufacturerId.Should().Be(manufacturer.TheId);
-                car.CreatedAt.Date.Should().Be(DateTime.Today.Date);
-                car.Category.Should().Be(CarCategory.Sport);
-            }
-        }
+				context.Execute("INSERT INTO Car VALUES (@Name, @ModelYear, @CreatedAt, @Chassis, @Mileage, @Category, @ManufacturerId)", insertParameters);
+				var car = context.First<Car>("SELECT TOP 1 * FROM Car");
+				context.Commit();
 
-        [TestMethod]
-        public void G_DataContext_Should_Execute_A_Procedure()
-        {
-            using (var context = new DataContext())
-            {
-                var procedureParams = new { Status = "active" };
-                var whoResults = context.All<WhoResult>("EXEC sp_who @Status", procedureParams);
+				car.Id.Should().BeGreaterThan(0);
+				car.Name.Should().Be("Esprit Turbo");
+				car.ModelYear.Should().Be(1981);
+				car.Mileage.Should().Be(318.19850801);
+				car.ManufacturerId.Should().Be(manufacturer.TheId);
+				car.CreatedAt.Date.Should().Be(DateTime.Today.Date);
+				car.Category.Should().Be(CarCategory.Sport);
+			}
+		}
 
-                whoResults.Should().Contain(r => r.dbname == "ThunderTest" && r.cmd == "SELECT");
-            }
-        }
+		[TestMethod]
+		public void G_DataContext_Should_Execute_A_Procedure()
+		{
+			using (var context = new DataContext())
+			{
+				var procedureParams = new { Status = "active" };
+				var whoResults = context.All<WhoResult>("EXEC sp_who @Status", procedureParams);
 
-        [TestMethod]
-        public void H_DataContext_Reader_Should_Translate_DBNull_To_Null_Value()
-        {
-            using (var context = new DataContext())
-            {
-                context.Execute("UPDATE Car SET Name = NULL WHERE Name = 'Esprit Turbo'");
-                var car = context.First<Car>("SELECT * FROM Car WHERE Name IS NULL");
+				whoResults.Should().Contain(r => r.dbname == "ThunderTest" && r.cmd == "SELECT");
+			}
+		}
 
-                car.Name.Should().BeNull();
-            }
-        }
+		[TestMethod]
+		public void H_DataContext_Reader_Should_Translate_DBNull_To_Null_Value()
+		{
+			using (var context = new DataContext())
+			{
+				context.Execute("UPDATE Car SET Name = NULL WHERE Name = 'Esprit Turbo'");
+				var car = context.First<Car>("SELECT * FROM Car WHERE Name IS NULL");
 
-        [TestMethod]
-        [ExpectedException(typeof(SqlException))]
-        public void I_DataContext_Should_Throws_An_Exception_When_Execute_An_Incorrect_Command()
-        {
-            using (var context = new DataContext())
-            {
-                context.Execute("DELETE FROM Blargh");
-            }
-        }
+				car.Name.Should().BeNull();
+			}
+		}
 
-        [TestMethod]
-        public void J_DataContext_Reader_First_Should_Return_A_Null_Object_When_Query_Do_Not_Found_Items()
-        {
-            using (var context = new DataContext())
-            {
-                var car = context.First<Car>("SELECT * FROM Car WHERE Name = 'Fusca'");
+		[TestMethod]
+		[ExpectedException(typeof(SqlException))]
+		public void I_DataContext_Should_Throws_An_Exception_When_Execute_An_Incorrect_Command()
+		{
+			using (var context = new DataContext())
+			{
+				context.Execute("DELETE FROM Blargh");
+			}
+		}
 
-                car.Should().BeNull();
-            }
-        }
+		[TestMethod]
+		public void J_DataContext_Reader_First_Should_Return_A_Null_Object_When_Query_Do_Not_Found_Items()
+		{
+			using (var context = new DataContext())
+			{
+				var car = context.First<Car>("SELECT * FROM Car WHERE Name = 'Fusca'");
 
-        [TestMethod]
-        public void K_DataContext_Reader_All_Should_Return_An_Empty_Object_List_When_Query_Do_Not_Found_Items()
-        {
-            using (var context = new DataContext())
-            {
-                var cars = context.All<Car>("SELECT * FROM Car WHERE Name = 'Fusca'");
+				car.Should().BeNull();
+			}
+		}
 
-                cars.Should().BeEmpty();
-            }
-        }
+		[TestMethod]
+		public void K_DataContext_Reader_All_Should_Return_An_Empty_Object_List_When_Query_Do_Not_Found_Items()
+		{
+			using (var context = new DataContext())
+			{
+				var cars = context.All<Car>("SELECT * FROM Car WHERE Name = 'Fusca'");
 
-        [TestMethod]
-        [ExpectedException(typeof(SqlException))]
-        public void L_DataContext_Should_Throws_An_Exeption_When_A_Constraint_Was_Broken()
-        {
-            using (var context = new DataContext())
-            {
-                var insertParameters = new Car
-                {
-                    Name = "AGL 1113",
-                    ModelYear = 1964,
-                    Mileage = 1567922,
-                    ManufacturerId = 98765, // Invalid ManufacturerId
-                    Category = CarCategory.Transport
-                };
+				cars.Should().BeEmpty();
+			}
+		}
 
-                context.Execute("INSERT INTO Car VALUES (@Name, @ModelYear, @CreatedAt, @Chassis, @Mileage, @Category, @ManufacturerId)", insertParameters);
-            }
-        }
+		[TestMethod]
+		[ExpectedException(typeof(SqlException))]
+		public void L_DataContext_Should_Throws_An_Exeption_When_A_Constraint_Was_Broken()
+		{
+			using (var context = new DataContext())
+			{
+				var insertParameters = new Car
+				{
+					Name = "AGL 1113",
+					ModelYear = 1964,
+					Mileage = 1567922,
+					ManufacturerId = 98765, // Invalid ManufacturerId
+					Category = CarCategory.Transport
+				};
 
-        [TestMethod]
-        public void M_DataObject_Should_Insert_Item_From_Database_And_Set_Primery_Key()
-        {
-            var car = new Car { Name = "Aventador", ModelYear = 2011, Category = CarCategory.Sport };
-            carDataObject.Insert(car);
+				context.Execute("INSERT INTO Car VALUES (@Name, @ModelYear, @CreatedAt, @Chassis, @Mileage, @Category, @ManufacturerId)", insertParameters);
+			}
+		}
 
-            car.Id.Should().BeGreaterThan(0);
+		[TestMethod]
+		public void M_DataObject_Should_Insert_Item_From_Database_And_Set_Primery_Key()
+		{
+			var car = new Car { Name = "Aventador", ModelYear = 2011, Category = CarCategory.Sport };
+			carDataObject.Insert(car);
 
-            using (var context = new DataContext())
-            {
-                var query = "SELECT TOP 1 * FROM Car WHERE Name = 'Aventador'";
-                var createdManufacturer = context.First<Car>(query);
+			car.Id.Should().BeGreaterThan(0);
 
-                createdManufacturer.Should().NotBeNull();
-            }
-        }
+			using (var context = new DataContext())
+			{
+				var query = "SELECT TOP 1 * FROM Car WHERE Name = 'Aventador'";
+				var createdManufacturer = context.First<Car>(query);
 
-        [TestMethod]
-        public void N_DataObject_Should_Read_Item_From_Database()
-        {
-            var car = carDataObject.Select.First("WHERE Name = 'Aventador'");
+				createdManufacturer.Should().NotBeNull();
+			}
+		}
 
-            car.Name.Should().Be("Aventador");
-            car.ModelYear.Should().Be(2011);
-        }
+		[TestMethod]
+		public void N_DataObject_Should_Read_Item_From_Database()
+		{
+			var car = carDataObject.Select.First("WHERE Name = 'Aventador'");
 
-        [TestMethod]
-        public void O_DataObject_Should_Create_Item_From_Database_With_Custom_Table_Name_And_Primary_Key()
-        {
-            var manufacturer = new Manufacturer { Name = "Lamborghini", BuildYear = 1963 };
-            manufacturerDataObject.Insert(manufacturer);
-            var queryParams = new { Name = "Lamborghini" };
-            var createdManufacturer = manufacturerDataObject.Select.First("WHERE Name = @Name", queryParams);
+			car.Name.Should().Be("Aventador");
+			car.ModelYear.Should().Be(2011);
+		}
 
-            manufacturer.TheId.Should().BeGreaterThan(0);
-            createdManufacturer.Name.Should().Be("Lamborghini");
-            createdManufacturer.BuildYear.Should().Be(1963);
-        }
+		[TestMethod]
+		public void O_DataObject_Should_Create_Item_From_Database_With_Custom_Table_Name_And_Primary_Key()
+		{
+			var manufacturer = new Manufacturer { Name = "Lamborghini", BuildYear = 1963 };
+			manufacturerDataObject.Insert(manufacturer);
+			var queryParams = new { Name = "Lamborghini" };
+			var createdManufacturer = manufacturerDataObject.Select.First("WHERE Name = @Name", queryParams);
 
-        [TestMethod]
-        public void P_DataObject_Should_Update_Item_From_Database()
-        {
-            var lamborghini = manufacturerDataObject.Select.First("WHERE Name = 'Lamborghini'");
-            var aventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
-            aventador.ManufacturerId = lamborghini.TheId;
-            carDataObject.Update(aventador);
-        }
+			manufacturer.TheId.Should().BeGreaterThan(0);
+			createdManufacturer.Name.Should().Be("Lamborghini");
+			createdManufacturer.BuildYear.Should().Be(1963);
+		}
 
-        [TestMethod]
-        public void Q_DataObject_Should_Read_All_Items_From_Database()
-        {
-            var cars = carDataObject.Select.All();
+		[TestMethod]
+		public void P_DataObject_Should_Update_Item_From_Database()
+		{
+			var lamborghini = manufacturerDataObject.Select.First("WHERE Name = 'Lamborghini'");
+			var aventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
+			aventador.ManufacturerId = lamborghini.TheId;
+			carDataObject.Update(aventador);
+		}
 
-            cars.Count().Should().Be(2);
-            cars.Should().Contain(c => c.Name == "Esprit Turbo");
-            cars.Should().Contain(c => c.Name == "Aventador");
-        }
+		[TestMethod]
+		public void Q_DataObject_Should_Read_All_Items_From_Database()
+		{
+			var cars = carDataObject.Select.All();
 
-        [TestMethod]
-        public void R_DataObject_Should_Delete_Item_From_Database()
-        {
-            var aventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
-            carDataObject.Delete(aventador);
-            var deletedAventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
+			cars.Count().Should().Be(2);
+			cars.Should().Contain(c => c.Name == "Esprit Turbo");
+			cars.Should().Contain(c => c.Name == "Aventador");
+		}
 
-            deletedAventador.Should().BeNull();
-        }
+		[TestMethod]
+		public void R_DataObject_Should_Delete_Item_From_Database()
+		{
+			var aventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
+			carDataObject.Delete(aventador);
+			var deletedAventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
 
-        [TestMethod]
-        public void S_DataObject_Should_CRUD_An_Item_With_Shared_Transactional_Data_Context()
-        {
-            using (var context = new DataContext())
-            {
-                var dodge = new Manufacturer { Name = "Dodge", BuildYear = 1900 };
-                manufacturerDataObject.Insert(dodge, context);
+			deletedAventador.Should().BeNull();
+		}
 
-                dodge.BuildYear = 1915;
-                manufacturerDataObject.Update(dodge, context);
-                var updatedDodge = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer WHERE Name = 'Dodge'");
-                
-                var m4s = new Car { Name = "M4S", ModelYear = 1984, Category = CarCategory.Prototype, ManufacturerId = dodge.TheId };
-                carDataObject.Insert(m4s, context);
-                var createdM4s = carDataObject.Select.With(context).First("WHERE Name = 'M4S'");
+		[TestMethod]
+		public void S_DataObject_Should_CRUD_An_Item_With_Shared_Transactional_Data_Context()
+		{
+			using (var context = new DataContext())
+			{
+				var dodge = new Manufacturer { Name = "Dodge", BuildYear = 1900 };
+				manufacturerDataObject.Insert(dodge, context);
 
-                carDataObject.Delete(m4s, context);
-                var deletedM4s = carDataObject.Select.With(context).First("WHERE Name = 'M4S'");
+				dodge.BuildYear = 1915;
+				manufacturerDataObject.Update(dodge, context);
+				var updatedDodge = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer WHERE Name = 'Dodge'");
 
-                updatedDodge.BuildYear.Should().Be(1915);
-                createdM4s.Should().NotBeNull();
-                deletedM4s.Should().BeNull();
+				var m4s = new Car { Name = "M4S", ModelYear = 1984, Category = CarCategory.Prototype, ManufacturerId = dodge.TheId };
+				carDataObject.Insert(m4s, context);
+				var createdM4s = carDataObject.Select.With(context).First("WHERE Name = 'M4S'");
 
-                context.Commit();
-            }
+				carDataObject.Delete(m4s, context);
+				var deletedM4s = carDataObject.Select.With(context).First("WHERE Name = 'M4S'");
 
-            var createdDodgeOutsiteContext = manufacturerDataObject.Select.First("WHERE Name = 'Dodge'");
-            createdDodgeOutsiteContext.Should().NotBeNull();
-        }
+				updatedDodge.BuildYear.Should().Be(1915);
+				createdM4s.Should().NotBeNull();
+				deletedM4s.Should().BeNull();
 
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-            ProviderFactory.CustomProvider = null;
-            ProviderFactory.ConnectionFactory = null;
+				context.Commit();
+			}
 
-            environment.Dispose();
-        }
-    }
+			var createdDodgeOutsiteContext = manufacturerDataObject.Select.First("WHERE Name = 'Dodge'");
+			createdDodgeOutsiteContext.Should().NotBeNull();
+		}
+
+		[TestMethod]
+		public void T_DataObject_Can_Be_ExpandoObject()
+		{
+			using (var context = new DataContext())
+			{
+				dynamic car = context.First<ExpandoObject>("SELECT Name, CreatedAt as CreatedOn FROM Car");
+
+				Assert.AreEqual("Esprit Turbo", car.Name);
+				Assert.AreEqual(DateTime.Today.Date, car.CreatedOn);
+			}
+		}
+
+		[ClassCleanup]
+		public static void ClassCleanup()
+		{
+			ProviderFactory.CustomProvider = null;
+			ProviderFactory.ConnectionFactory = null;
+
+			environment.Dispose();
+		}
+	}
 }

--- a/Thunderstruck.Test/Functional/SqlTest.cs
+++ b/Thunderstruck.Test/Functional/SqlTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Data.SqlClient;
 using Thunderstruck.Provider;
 using System.Dynamic;
+using System.Collections.Generic;
 
 namespace Thunderstruck.Test.Functional
 {
@@ -348,6 +349,15 @@ namespace Thunderstruck.Test.Functional
 
 				Assert.AreEqual("Esprit Turbo", car.Name);
 				Assert.AreEqual(DateTime.Today.Date, car.CreatedOn);
+			}
+
+			using (var context = new DataContext())
+			{
+				IEnumerable<dynamic> cars = context.All<ExpandoObject>("SELECT * FROM Car");
+				
+				Assert.AreEqual(1, cars.Count());
+				Assert.AreEqual("Esprit Turbo", cars.First().Name);
+				Assert.AreEqual(DateTime.Today.Date, cars.First().CreatedAt);
 			}
 		}
 

--- a/Thunderstruck.Test/Functional/SqlTest.cs
+++ b/Thunderstruck.Test/Functional/SqlTest.cs
@@ -10,364 +10,364 @@ using System.Collections.Generic;
 
 namespace Thunderstruck.Test.Functional
 {
-	[TestClass]
-	public class SqlTest
-	{
-		private static SqlEnvironment environment;
-		private DataObject<Car> carDataObject;
-		private DataObject<Manufacturer> manufacturerDataObject;
+    [TestClass]
+    public class SqlTest
+    {
+        private static SqlEnvironment environment;
+        private DataObject<Car> carDataObject;
+        private DataObject<Manufacturer> manufacturerDataObject;
 
-		[ClassInitialize]
-		public static void ClassInitialize(TestContext tests)
-		{
-			environment = new SqlEnvironment();
-		}
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext tests)
+        {
+            environment = new SqlEnvironment();
+        }
 
-		[TestInitialize]
-		public void Initialize()
-		{
-			carDataObject = new DataObject<Car>();
-			manufacturerDataObject = new DataObject<Manufacturer>(table: "Le_Manufacturer", primaryKey: "TheId");
+        [TestInitialize]
+        public void Initialize()
+        {
+            carDataObject = new DataObject<Car>();
+            manufacturerDataObject = new DataObject<Manufacturer>(table: "Le_Manufacturer", primaryKey: "TheId");
 
-			ProviderFactory.CustomProvider = null;
-			ProviderFactory.ConnectionFactory = null;
-		}
+            ProviderFactory.CustomProvider = null;
+            ProviderFactory.ConnectionFactory = null;
+        }
 
-		[TestMethod]
-		public void A_DataContext_Transitional_Should_Execute_A_Insert_SQL_Command_With_Anonymous_Object_Parameters_And_Read_Created_Data_In_Same_And_Count_Data_In_Another_Context()
-		{
-			using (var context = new DataContext())
-			{
-				var insertParameters = new { Name = "Lotus", Year = 1952 };
-				context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
-				var manufacturer = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer");
-				context.Commit();
+        [TestMethod]
+        public void A_DataContext_Transitional_Should_Execute_A_Insert_SQL_Command_With_Anonymous_Object_Parameters_And_Read_Created_Data_In_Same_And_Count_Data_In_Another_Context()
+        {
+            using (var context = new DataContext())
+            {
+                var insertParameters = new { Name = "Lotus", Year = 1952 };
+                context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
+                var manufacturer = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer");
+                context.Commit();
 
-				manufacturer.TheId.Should().BeGreaterThan(0);
-				manufacturer.Name.Should().Be("Lotus");
-				manufacturer.BuildYear.Should().Be(1952);
-			}
+                manufacturer.TheId.Should().BeGreaterThan(0);
+                manufacturer.Name.Should().Be("Lotus");
+                manufacturer.BuildYear.Should().Be(1952);
+            }
 
-			using (var context = new DataContext())
-			{
-				var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
+            using (var context = new DataContext())
+            {
+                var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
 
-				manufacturerCount.Should().Be(1);
-			}
-		}
+                manufacturerCount.Should().Be(1);
+            }
+        }
 
-		[TestMethod]
-		public void B_DataContext_Transitional_Should_Execute_A_Insert_SQL_Command_With_Array_Parameters_And_Read_Created_Data_In_Same_And_Count_Data_In_Another_Context()
-		{
-			using (var context = new DataContext())
-			{
-				context.Execute("INSERT INTO Le_Manufacturer VALUES (@0, @1)", "McLaren", 1963);
-				var manufacturer = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer WHERE Name = @0", "McLaren");
-				context.Commit();
+        [TestMethod]
+        public void B_DataContext_Transitional_Should_Execute_A_Insert_SQL_Command_With_Array_Parameters_And_Read_Created_Data_In_Same_And_Count_Data_In_Another_Context()
+        {
+            using (var context = new DataContext())
+            {
+                context.Execute("INSERT INTO Le_Manufacturer VALUES (@0, @1)", "McLaren", 1963);
+                var manufacturer = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer WHERE Name = @0", "McLaren");
+                context.Commit();
 
-				manufacturer.TheId.Should().BeGreaterThan(0);
-				manufacturer.Name.Should().Be("McLaren");
-				manufacturer.BuildYear.Should().Be(1963);
-			}
+                manufacturer.TheId.Should().BeGreaterThan(0);
+                manufacturer.Name.Should().Be("McLaren");
+                manufacturer.BuildYear.Should().Be(1963);
+            }
 
-			using (var context = new DataContext())
-			{
-				var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
+            using (var context = new DataContext())
+            {
+                var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
 
-				manufacturerCount.Should().Be(2);
-			}
-		}
+                manufacturerCount.Should().Be(2);
+            }
+        }
 
-		[TestMethod]
-		public void C_DataContext_Non_Transitional_Should_Execute_A_Insert_SQL_Command_With_Object_Parameters_And_Read_Created_Data_In_Same_And_Count_Data()
-		{
-			using (var context = new DataContext(Transaction.No))
-			{
-				var insertParameters = new Manufacturer { Name = "General Motors", BuildYear = 1908 };
-				context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @BuildYear)", insertParameters);
-				var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE BuildYear = 1908");
-				var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
+        [TestMethod]
+        public void C_DataContext_Non_Transitional_Should_Execute_A_Insert_SQL_Command_With_Object_Parameters_And_Read_Created_Data_In_Same_And_Count_Data()
+        {
+            using (var context = new DataContext(Transaction.No))
+            {
+                var insertParameters = new Manufacturer { Name = "General Motors", BuildYear = 1908 };
+                context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @BuildYear)", insertParameters);
+                var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE BuildYear = 1908");
+                var manufacturerCount = context.GetValue<int>("SELECT COUNT(TheId) FROM Le_Manufacturer");
 
-				manufacturer.TheId.Should().BeGreaterThan(0);
-				manufacturer.Name.Should().Be("General Motors");
-				manufacturer.BuildYear.Should().Be(1908);
-				manufacturerCount.Should().Be(3);
-			}
-		}
+                manufacturer.TheId.Should().BeGreaterThan(0);
+                manufacturer.Name.Should().Be("General Motors");
+                manufacturer.BuildYear.Should().Be(1908);
+                manufacturerCount.Should().Be(3);
+            }
+        }
 
-		[TestMethod]
-		public void D_DataContext_Transitional_Should_Not_Commit_Data_If_Not_Explicit_Commit_Command_Call()
-		{
-			using (var context = new DataContext())
-			{
-				var insertParameters = new { Name = "Bentley", Year = 1919 };
-				context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
-			}
+        [TestMethod]
+        public void D_DataContext_Transitional_Should_Not_Commit_Data_If_Not_Explicit_Commit_Command_Call()
+        {
+            using (var context = new DataContext())
+            {
+                var insertParameters = new { Name = "Bentley", Year = 1919 };
+                context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
+            }
 
-			using (var context = new DataContext())
-			{
-				var manufacturers = context.All<Manufacturer>("SELECT * FROM Le_Manufacturer");
+            using (var context = new DataContext())
+            {
+                var manufacturers = context.All<Manufacturer>("SELECT * FROM Le_Manufacturer");
 
-				manufacturers.Count().Should().Be(3);
-				manufacturers.Should().Contain(m => m.Name == "Lotus");
-				manufacturers.Should().Contain(m => m.Name == "General Motors");
-			}
-		}
+                manufacturers.Count().Should().Be(3);
+                manufacturers.Should().Contain(m => m.Name == "Lotus");
+                manufacturers.Should().Contain(m => m.Name == "General Motors");
+            }
+        }
 
-		[TestMethod]
-		public void E_DataContext_Transitional_Should_Execute_A_SQL_And_Share_Transaction_With_A_Data_Reader()
-		{
-			using (var context = new DataContext())
-			{
-				var insertParameters = new { Name = "BMW", Year = 1916 };
-				context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
-				var selectParameters = new { Name = "BMW" };
-				var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
+        [TestMethod]
+        public void E_DataContext_Transitional_Should_Execute_A_SQL_And_Share_Transaction_With_A_Data_Reader()
+        {
+            using (var context = new DataContext())
+            {
+                var insertParameters = new { Name = "BMW", Year = 1916 };
+                context.Execute("INSERT INTO Le_Manufacturer VALUES (@Name, @Year)", insertParameters);
+                var selectParameters = new { Name = "BMW" };
+                var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
 
-				manufacturer.Should().NotBeNull();
-			}
+                manufacturer.Should().NotBeNull();
+            }
 
-			using (var context = new DataContext())
-			{
-				var selectParameters = new { Name = "BMW" };
-				var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
+            using (var context = new DataContext())
+            {
+                var selectParameters = new { Name = "BMW" };
+                var manufacturer = context.First<Manufacturer>("SELECT * FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
 
-				manufacturer.Should().BeNull();
-			}
-		}
+                manufacturer.Should().BeNull();
+            }
+        }
 
-		[TestMethod]
-		public void F_DataContext_Should_Read_Data_With_One_Field_And_Insert_A_Data_With_Some_Parameters_Types()
-		{
-			using (var context = new DataContext())
-			{
-				var selectParameters = new { Name = "Lotus" };
-				var manufacturer = context.First<Manufacturer>("SELECT TheId FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
+        [TestMethod]
+        public void F_DataContext_Should_Read_Data_With_One_Field_And_Insert_A_Data_With_Some_Parameters_Types()
+        {
+            using (var context = new DataContext())
+            {
+                var selectParameters = new { Name = "Lotus" };
+                var manufacturer = context.First<Manufacturer>("SELECT TheId FROM Le_Manufacturer WHERE Name = @Name", selectParameters);
 
-				var insertParameters = new Car
-				{
-					Name = "Esprit Turbo",
-					ModelYear = 1981,
-					Mileage = 318.19850801,
-					ManufacturerId = manufacturer.TheId,
-					Category = CarCategory.Sport
-				};
+                var insertParameters = new Car
+                {
+                    Name = "Esprit Turbo",
+                    ModelYear = 1981,
+                    Mileage = 318.19850801,
+                    ManufacturerId = manufacturer.TheId,
+                    Category = CarCategory.Sport
+                };
 
-				context.Execute("INSERT INTO Car VALUES (@Name, @ModelYear, @CreatedAt, @Chassis, @Mileage, @Category, @ManufacturerId)", insertParameters);
-				var car = context.First<Car>("SELECT TOP 1 * FROM Car");
-				context.Commit();
+                context.Execute("INSERT INTO Car VALUES (@Name, @ModelYear, @CreatedAt, @Chassis, @Mileage, @Category, @ManufacturerId)", insertParameters);
+                var car = context.First<Car>("SELECT TOP 1 * FROM Car");
+                context.Commit();
 
-				car.Id.Should().BeGreaterThan(0);
-				car.Name.Should().Be("Esprit Turbo");
-				car.ModelYear.Should().Be(1981);
-				car.Mileage.Should().Be(318.19850801);
-				car.ManufacturerId.Should().Be(manufacturer.TheId);
-				car.CreatedAt.Date.Should().Be(DateTime.Today.Date);
-				car.Category.Should().Be(CarCategory.Sport);
-			}
-		}
+                car.Id.Should().BeGreaterThan(0);
+                car.Name.Should().Be("Esprit Turbo");
+                car.ModelYear.Should().Be(1981);
+                car.Mileage.Should().Be(318.19850801);
+                car.ManufacturerId.Should().Be(manufacturer.TheId);
+                car.CreatedAt.Date.Should().Be(DateTime.Today.Date);
+                car.Category.Should().Be(CarCategory.Sport);
+            }
+        }
 
-		[TestMethod]
-		public void G_DataContext_Should_Execute_A_Procedure()
-		{
-			using (var context = new DataContext())
-			{
-				var procedureParams = new { Status = "active" };
-				var whoResults = context.All<WhoResult>("EXEC sp_who @Status", procedureParams);
+        [TestMethod]
+        public void G_DataContext_Should_Execute_A_Procedure()
+        {
+            using (var context = new DataContext())
+            {
+                var procedureParams = new { Status = "active" };
+                var whoResults = context.All<WhoResult>("EXEC sp_who @Status", procedureParams);
 
-				whoResults.Should().Contain(r => r.dbname == "ThunderTest" && r.cmd == "SELECT");
-			}
-		}
+                whoResults.Should().Contain(r => r.dbname == "ThunderTest" && r.cmd == "SELECT");
+            }
+        }
 
-		[TestMethod]
-		public void H_DataContext_Reader_Should_Translate_DBNull_To_Null_Value()
-		{
-			using (var context = new DataContext())
-			{
-				context.Execute("UPDATE Car SET Name = NULL WHERE Name = 'Esprit Turbo'");
-				var car = context.First<Car>("SELECT * FROM Car WHERE Name IS NULL");
+        [TestMethod]
+        public void H_DataContext_Reader_Should_Translate_DBNull_To_Null_Value()
+        {
+            using (var context = new DataContext())
+            {
+                context.Execute("UPDATE Car SET Name = NULL WHERE Name = 'Esprit Turbo'");
+                var car = context.First<Car>("SELECT * FROM Car WHERE Name IS NULL");
 
-				car.Name.Should().BeNull();
-			}
-		}
+                car.Name.Should().BeNull();
+            }
+        }
 
-		[TestMethod]
-		[ExpectedException(typeof(SqlException))]
-		public void I_DataContext_Should_Throws_An_Exception_When_Execute_An_Incorrect_Command()
-		{
-			using (var context = new DataContext())
-			{
-				context.Execute("DELETE FROM Blargh");
-			}
-		}
+        [TestMethod]
+        [ExpectedException(typeof(SqlException))]
+        public void I_DataContext_Should_Throws_An_Exception_When_Execute_An_Incorrect_Command()
+        {
+            using (var context = new DataContext())
+            {
+                context.Execute("DELETE FROM Blargh");
+            }
+        }
 
-		[TestMethod]
-		public void J_DataContext_Reader_First_Should_Return_A_Null_Object_When_Query_Do_Not_Found_Items()
-		{
-			using (var context = new DataContext())
-			{
-				var car = context.First<Car>("SELECT * FROM Car WHERE Name = 'Fusca'");
+        [TestMethod]
+        public void J_DataContext_Reader_First_Should_Return_A_Null_Object_When_Query_Do_Not_Found_Items()
+        {
+            using (var context = new DataContext())
+            {
+                var car = context.First<Car>("SELECT * FROM Car WHERE Name = 'Fusca'");
 
-				car.Should().BeNull();
-			}
-		}
+                car.Should().BeNull();
+            }
+        }
 
-		[TestMethod]
-		public void K_DataContext_Reader_All_Should_Return_An_Empty_Object_List_When_Query_Do_Not_Found_Items()
-		{
-			using (var context = new DataContext())
-			{
-				var cars = context.All<Car>("SELECT * FROM Car WHERE Name = 'Fusca'");
+        [TestMethod]
+        public void K_DataContext_Reader_All_Should_Return_An_Empty_Object_List_When_Query_Do_Not_Found_Items()
+        {
+            using (var context = new DataContext())
+            {
+                var cars = context.All<Car>("SELECT * FROM Car WHERE Name = 'Fusca'");
 
-				cars.Should().BeEmpty();
-			}
-		}
+                cars.Should().BeEmpty();
+            }
+        }
 
-		[TestMethod]
-		[ExpectedException(typeof(SqlException))]
-		public void L_DataContext_Should_Throws_An_Exeption_When_A_Constraint_Was_Broken()
-		{
-			using (var context = new DataContext())
-			{
-				var insertParameters = new Car
-				{
-					Name = "AGL 1113",
-					ModelYear = 1964,
-					Mileage = 1567922,
-					ManufacturerId = 98765, // Invalid ManufacturerId
-					Category = CarCategory.Transport
-				};
+        [TestMethod]
+        [ExpectedException(typeof(SqlException))]
+        public void L_DataContext_Should_Throws_An_Exeption_When_A_Constraint_Was_Broken()
+        {
+            using (var context = new DataContext())
+            {
+                var insertParameters = new Car
+                {
+                    Name = "AGL 1113",
+                    ModelYear = 1964,
+                    Mileage = 1567922,
+                    ManufacturerId = 98765, // Invalid ManufacturerId
+                    Category = CarCategory.Transport
+                };
 
-				context.Execute("INSERT INTO Car VALUES (@Name, @ModelYear, @CreatedAt, @Chassis, @Mileage, @Category, @ManufacturerId)", insertParameters);
-			}
-		}
+                context.Execute("INSERT INTO Car VALUES (@Name, @ModelYear, @CreatedAt, @Chassis, @Mileage, @Category, @ManufacturerId)", insertParameters);
+            }
+        }
 
-		[TestMethod]
-		public void M_DataObject_Should_Insert_Item_From_Database_And_Set_Primery_Key()
-		{
-			var car = new Car { Name = "Aventador", ModelYear = 2011, Category = CarCategory.Sport };
-			carDataObject.Insert(car);
+        [TestMethod]
+        public void M_DataObject_Should_Insert_Item_From_Database_And_Set_Primery_Key()
+        {
+            var car = new Car { Name = "Aventador", ModelYear = 2011, Category = CarCategory.Sport };
+            carDataObject.Insert(car);
 
-			car.Id.Should().BeGreaterThan(0);
+            car.Id.Should().BeGreaterThan(0);
 
-			using (var context = new DataContext())
-			{
-				var query = "SELECT TOP 1 * FROM Car WHERE Name = 'Aventador'";
-				var createdManufacturer = context.First<Car>(query);
+            using (var context = new DataContext())
+            {
+                var query = "SELECT TOP 1 * FROM Car WHERE Name = 'Aventador'";
+                var createdManufacturer = context.First<Car>(query);
 
-				createdManufacturer.Should().NotBeNull();
-			}
-		}
+                createdManufacturer.Should().NotBeNull();
+            }
+        }
 
-		[TestMethod]
-		public void N_DataObject_Should_Read_Item_From_Database()
-		{
-			var car = carDataObject.Select.First("WHERE Name = 'Aventador'");
+        [TestMethod]
+        public void N_DataObject_Should_Read_Item_From_Database()
+        {
+            var car = carDataObject.Select.First("WHERE Name = 'Aventador'");
 
-			car.Name.Should().Be("Aventador");
-			car.ModelYear.Should().Be(2011);
-		}
+            car.Name.Should().Be("Aventador");
+            car.ModelYear.Should().Be(2011);
+        }
 
-		[TestMethod]
-		public void O_DataObject_Should_Create_Item_From_Database_With_Custom_Table_Name_And_Primary_Key()
-		{
-			var manufacturer = new Manufacturer { Name = "Lamborghini", BuildYear = 1963 };
-			manufacturerDataObject.Insert(manufacturer);
-			var queryParams = new { Name = "Lamborghini" };
-			var createdManufacturer = manufacturerDataObject.Select.First("WHERE Name = @Name", queryParams);
+        [TestMethod]
+        public void O_DataObject_Should_Create_Item_From_Database_With_Custom_Table_Name_And_Primary_Key()
+        {
+            var manufacturer = new Manufacturer { Name = "Lamborghini", BuildYear = 1963 };
+            manufacturerDataObject.Insert(manufacturer);
+            var queryParams = new { Name = "Lamborghini" };
+            var createdManufacturer = manufacturerDataObject.Select.First("WHERE Name = @Name", queryParams);
 
-			manufacturer.TheId.Should().BeGreaterThan(0);
-			createdManufacturer.Name.Should().Be("Lamborghini");
-			createdManufacturer.BuildYear.Should().Be(1963);
-		}
+            manufacturer.TheId.Should().BeGreaterThan(0);
+            createdManufacturer.Name.Should().Be("Lamborghini");
+            createdManufacturer.BuildYear.Should().Be(1963);
+        }
 
-		[TestMethod]
-		public void P_DataObject_Should_Update_Item_From_Database()
-		{
-			var lamborghini = manufacturerDataObject.Select.First("WHERE Name = 'Lamborghini'");
-			var aventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
-			aventador.ManufacturerId = lamborghini.TheId;
-			carDataObject.Update(aventador);
-		}
+        [TestMethod]
+        public void P_DataObject_Should_Update_Item_From_Database()
+        {
+            var lamborghini = manufacturerDataObject.Select.First("WHERE Name = 'Lamborghini'");
+            var aventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
+            aventador.ManufacturerId = lamborghini.TheId;
+            carDataObject.Update(aventador);
+        }
 
-		[TestMethod]
-		public void Q_DataObject_Should_Read_All_Items_From_Database()
-		{
-			var cars = carDataObject.Select.All();
+        [TestMethod]
+        public void Q_DataObject_Should_Read_All_Items_From_Database()
+        {
+            var cars = carDataObject.Select.All();
 
-			cars.Count().Should().Be(2);
-			cars.Should().Contain(c => c.Name == "Esprit Turbo");
-			cars.Should().Contain(c => c.Name == "Aventador");
-		}
+            cars.Count().Should().Be(2);
+            cars.Should().Contain(c => c.Name == "Esprit Turbo");
+            cars.Should().Contain(c => c.Name == "Aventador");
+        }
 
-		[TestMethod]
-		public void R_DataObject_Should_Delete_Item_From_Database()
-		{
-			var aventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
-			carDataObject.Delete(aventador);
-			var deletedAventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
+        [TestMethod]
+        public void R_DataObject_Should_Delete_Item_From_Database()
+        {
+            var aventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
+            carDataObject.Delete(aventador);
+            var deletedAventador = carDataObject.Select.First("WHERE Name = 'Aventador'");
 
-			deletedAventador.Should().BeNull();
-		}
+            deletedAventador.Should().BeNull();
+        }
 
-		[TestMethod]
-		public void S_DataObject_Should_CRUD_An_Item_With_Shared_Transactional_Data_Context()
-		{
-			using (var context = new DataContext())
-			{
-				var dodge = new Manufacturer { Name = "Dodge", BuildYear = 1900 };
-				manufacturerDataObject.Insert(dodge, context);
+        [TestMethod]
+        public void S_DataObject_Should_CRUD_An_Item_With_Shared_Transactional_Data_Context()
+        {
+            using (var context = new DataContext())
+            {
+                var dodge = new Manufacturer { Name = "Dodge", BuildYear = 1900 };
+                manufacturerDataObject.Insert(dodge, context);
 
-				dodge.BuildYear = 1915;
-				manufacturerDataObject.Update(dodge, context);
-				var updatedDodge = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer WHERE Name = 'Dodge'");
+                dodge.BuildYear = 1915;
+                manufacturerDataObject.Update(dodge, context);
+                var updatedDodge = context.First<Manufacturer>("SELECT TOP 1 * FROM Le_Manufacturer WHERE Name = 'Dodge'");
 
-				var m4s = new Car { Name = "M4S", ModelYear = 1984, Category = CarCategory.Prototype, ManufacturerId = dodge.TheId };
-				carDataObject.Insert(m4s, context);
-				var createdM4s = carDataObject.Select.With(context).First("WHERE Name = 'M4S'");
+                var m4s = new Car { Name = "M4S", ModelYear = 1984, Category = CarCategory.Prototype, ManufacturerId = dodge.TheId };
+                carDataObject.Insert(m4s, context);
+                var createdM4s = carDataObject.Select.With(context).First("WHERE Name = 'M4S'");
 
-				carDataObject.Delete(m4s, context);
-				var deletedM4s = carDataObject.Select.With(context).First("WHERE Name = 'M4S'");
+                carDataObject.Delete(m4s, context);
+                var deletedM4s = carDataObject.Select.With(context).First("WHERE Name = 'M4S'");
 
-				updatedDodge.BuildYear.Should().Be(1915);
-				createdM4s.Should().NotBeNull();
-				deletedM4s.Should().BeNull();
+                updatedDodge.BuildYear.Should().Be(1915);
+                createdM4s.Should().NotBeNull();
+                deletedM4s.Should().BeNull();
 
-				context.Commit();
-			}
+                context.Commit();
+            }
 
-			var createdDodgeOutsiteContext = manufacturerDataObject.Select.First("WHERE Name = 'Dodge'");
-			createdDodgeOutsiteContext.Should().NotBeNull();
-		}
+            var createdDodgeOutsiteContext = manufacturerDataObject.Select.First("WHERE Name = 'Dodge'");
+            createdDodgeOutsiteContext.Should().NotBeNull();
+        }
 
-		[TestMethod]
-		public void T_DataObject_Can_Be_ExpandoObject()
-		{
-			using (var context = new DataContext())
-			{
-				dynamic car = context.First<ExpandoObject>("SELECT Name, CreatedAt as CreatedOn FROM Car");
+        [TestMethod]
+        public void T_DataObject_Can_Be_ExpandoObject()
+        {
+            using (var context = new DataContext())
+            {
+                dynamic car = context.First<ExpandoObject>("SELECT Name, CreatedAt as CreatedOn FROM Car");
 
-				Assert.AreEqual("Esprit Turbo", car.Name);
-				Assert.AreEqual(DateTime.Today.Date, car.CreatedOn);
-			}
+                Assert.AreEqual("Esprit Turbo", car.Name);
+                Assert.AreEqual(DateTime.Today.Date, car.CreatedOn);
+            }
 
-			using (var context = new DataContext())
-			{
-				IEnumerable<dynamic> cars = context.All<ExpandoObject>("SELECT * FROM Car");
-				
-				Assert.AreEqual(1, cars.Count());
-				Assert.AreEqual("Esprit Turbo", cars.First().Name);
-				Assert.AreEqual(DateTime.Today.Date, cars.First().CreatedAt);
-			}
-		}
+            using (var context = new DataContext())
+            {
+                IEnumerable<dynamic> cars = context.All<ExpandoObject>("SELECT * FROM Car");
 
-		[ClassCleanup]
-		public static void ClassCleanup()
-		{
-			ProviderFactory.CustomProvider = null;
-			ProviderFactory.ConnectionFactory = null;
+                Assert.AreEqual(1, cars.Count());
+                Assert.AreEqual("Esprit Turbo", cars.First().Name);
+                Assert.AreEqual(DateTime.Today.Date, cars.First().CreatedAt);
+            }
+        }
 
-			environment.Dispose();
-		}
-	}
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            ProviderFactory.CustomProvider = null;
+            ProviderFactory.ConnectionFactory = null;
+
+            environment.Dispose();
+        }
+    }
 }

--- a/Thunderstruck.Test/Properties/AssemblyInfo.cs
+++ b/Thunderstruck.Test/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.2")]
-[assembly: AssemblyFileVersion("0.2.2")]
+[assembly: AssemblyVersion("0.2.3")]
+[assembly: AssemblyFileVersion("0.2.3")]

--- a/Thunderstruck.Test/Properties/AssemblyInfo.cs
+++ b/Thunderstruck.Test/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.3")]
-[assembly: AssemblyFileVersion("0.2.3")]
+[assembly: AssemblyVersion("0.2.4")]
+[assembly: AssemblyFileVersion("0.2.4")]

--- a/Thunderstruck.Test/Thunderstruck.Test.csproj
+++ b/Thunderstruck.Test/Thunderstruck.Test.csproj
@@ -40,6 +40,7 @@
     <Reference Include="FluentAssertions">
       <HintPath>..\packages\FluentAssertions.2.0.1\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>

--- a/Thunderstruck.Test/Unit/ProviderFactoryTest.cs
+++ b/Thunderstruck.Test/Unit/ProviderFactoryTest.cs
@@ -96,6 +96,26 @@ namespace Thunderstruck.Test.Unit
 			provider.Should().BeOfType<CustomProvider>();
 		}
 
+		[TestMethod]
+		public void ProviderFactory_Add_Provider_Same_Name_Same_Type()
+		{
+			ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
+			ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
+
+			// if we got here with no exception, we're good
+			Assert.IsTrue(true);
+		}
+
+		[TestMethod, ExpectedException(typeof(ThunderException))]
+		public void ProviderFactory_Add_Provider_Same_Name_Different_Type()
+		{
+			ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
+			ProviderFactory.AddProvider("Custom.Provider", typeof(SqlProvider));
+
+			// if we got here with no exception, we're not good
+			Assert.Fail();
+		}
+
 		public class CustomProvider : DefaultProvider
 		{
 			public override string ParameterIdentifier

--- a/Thunderstruck.Test/Unit/ProviderFactoryTest.cs
+++ b/Thunderstruck.Test/Unit/ProviderFactoryTest.cs
@@ -86,62 +86,62 @@ namespace Thunderstruck.Test.Unit
             provider.Should().Be(providerMock.Object);
         }
 
-		[TestMethod]
-		public void ProviderFactory_Add_Provider()
-		{
-			ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
+        [TestMethod]
+        public void ProviderFactory_Add_Provider()
+        {
+            ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
 
-			var provider = factory.ResolveDataProvider("Custom.Provider");
+            var provider = factory.ResolveDataProvider("Custom.Provider");
 
-			provider.Should().BeOfType<CustomProvider>();
-		}
+            provider.Should().BeOfType<CustomProvider>();
+        }
 
-		[TestMethod]
-		public void ProviderFactory_Add_Provider_Same_Name_Same_Type()
-		{
-			ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
-			ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
+        [TestMethod]
+        public void ProviderFactory_Add_Provider_Same_Name_Same_Type()
+        {
+            ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
+            ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
 
-			// if we got here with no exception, we're good
-			Assert.IsTrue(true);
-		}
+            // if we got here with no exception, we're good
+            Assert.IsTrue(true);
+        }
 
-		[TestMethod, ExpectedException(typeof(ThunderException))]
-		public void ProviderFactory_Add_Provider_Same_Name_Different_Type()
-		{
-			ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
-			ProviderFactory.AddProvider("Custom.Provider", typeof(SqlProvider));
+        [TestMethod, ExpectedException(typeof(ThunderException))]
+        public void ProviderFactory_Add_Provider_Same_Name_Different_Type()
+        {
+            ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
+            ProviderFactory.AddProvider("Custom.Provider", typeof(SqlProvider));
 
-			// if we got here with no exception, we're not good
-			Assert.Fail();
-		}
+            // if we got here with no exception, we're not good
+            Assert.Fail();
+        }
 
-		public class CustomProvider : DefaultProvider
-		{
-			public override string ParameterIdentifier
-			{
-				get { throw new NotImplementedException(); }
-			}
+        public class CustomProvider : DefaultProvider
+        {
+            public override string ParameterIdentifier
+            {
+                get { throw new NotImplementedException(); }
+            }
 
-			public override string FieldFormat
-			{
-				get { throw new NotImplementedException(); }
-			}
+            public override string FieldFormat
+            {
+                get { throw new NotImplementedException(); }
+            }
 
-			public override string SelectAllQuery(string projection, string where)
-			{
-				throw new NotImplementedException();
-			}
+            public override string SelectAllQuery(string projection, string where)
+            {
+                throw new NotImplementedException();
+            }
 
-			public override string SelectTakeQuery(string projection, string where, int count)
-			{
-				throw new NotImplementedException();
-			}
+            public override string SelectTakeQuery(string projection, string where, int count)
+            {
+                throw new NotImplementedException();
+            }
 
-			public override int ExecuteGetIdentity(string command, object[] commandParams)
-			{
-				throw new NotImplementedException();
-			}
-		}
+            public override int ExecuteGetIdentity(string command, object[] commandParams)
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/Thunderstruck.Test/Unit/ProviderFactoryTest.cs
+++ b/Thunderstruck.Test/Unit/ProviderFactoryTest.cs
@@ -85,5 +85,43 @@ namespace Thunderstruck.Test.Unit
 
             provider.Should().Be(providerMock.Object);
         }
+
+		[TestMethod]
+		public void ProviderFactory_Add_Provider()
+		{
+			ProviderFactory.AddProvider("Custom.Provider", typeof(CustomProvider));
+
+			var provider = factory.ResolveDataProvider("Custom.Provider");
+
+			provider.Should().BeOfType<CustomProvider>();
+		}
+
+		public class CustomProvider : DefaultProvider
+		{
+			public override string ParameterIdentifier
+			{
+				get { throw new NotImplementedException(); }
+			}
+
+			public override string FieldFormat
+			{
+				get { throw new NotImplementedException(); }
+			}
+
+			public override string SelectAllQuery(string projection, string where)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override string SelectTakeQuery(string projection, string where, int count)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override int ExecuteGetIdentity(string command, object[] commandParams)
+			{
+				throw new NotImplementedException();
+			}
+		}
     }
 }

--- a/Thunderstruck/Properties/AssemblyInfo.cs
+++ b/Thunderstruck/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.2")]
-[assembly: AssemblyFileVersion("0.2.2")]
+[assembly: AssemblyVersion("0.2.3")]
+[assembly: AssemblyFileVersion("0.2.3")]

--- a/Thunderstruck/Properties/AssemblyInfo.cs
+++ b/Thunderstruck/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.3")]
-[assembly: AssemblyFileVersion("0.2.3")]
+[assembly: AssemblyVersion("0.2.4")]
+[assembly: AssemblyFileVersion("0.2.4")]

--- a/Thunderstruck/Provider/ProviderFactory.cs
+++ b/Thunderstruck/Provider/ProviderFactory.cs
@@ -45,7 +45,7 @@ namespace Thunderstruck.Provider
 			var exceptionMessage = String.Format(
 				"Thunderstruck do not supports the '{0}' provider. Either add your provider using the ProviderFactory.AddProvider() method, or create and set a ProviderResolver.CustomProvider.",
 				providerName);
-		
+
 			throw new ThunderException(exceptionMessage);
 		}
 
@@ -71,8 +71,21 @@ namespace Thunderstruck.Provider
 			{
 				throw new ArgumentNullException("providerType");
 			}
+			if (Providers.ContainsKey(providerName))
+			{
+				if (!Providers[providerName].Equals(providerType))
+				{
+					var message = String.Format(
+						"Attempting to add a provider named '{0}' of type '{1}', but an existing provider of type '{2}' already exists with that name.",
+						providerName, providerType.ToString(), Providers[providerName].ToString());
 
-			Providers.Add(providerName, providerType);
+					throw new ThunderException(message);
+				}
+			}
+			else
+			{
+				Providers.Add(providerName, providerType);
+			}
 		}
 	}
 }

--- a/Thunderstruck/Provider/ProviderFactory.cs
+++ b/Thunderstruck/Provider/ProviderFactory.cs
@@ -8,84 +8,84 @@ using Thunderstruck.Provider.Common;
 
 namespace Thunderstruck.Provider
 {
-	public class ProviderFactory
-	{
-		public static Func<string, IDataProvider> CustomProvider { get; set; }
+    public class ProviderFactory
+    {
+        public static Func<string, IDataProvider> CustomProvider { get; set; }
 
-		public static Func<string, IDbConnection> ConnectionFactory { get; set; }
+        public static Func<string, IDbConnection> ConnectionFactory { get; set; }
 
-		private static Dictionary<string, Type> Providers;
+        private static Dictionary<string, Type> Providers;
 
-		static ProviderFactory()
-		{
-			Providers = new Dictionary<string, Type>();
+        static ProviderFactory()
+        {
+            Providers = new Dictionary<string, Type>();
 
-			AddProvider("System.Data.SqlClient", typeof(SqlProvider));
-			AddProvider("System.Data.OracleClient", typeof(OracleProvider));
-			AddProvider("MySql.Data.MySqlClient", typeof(MySqlProvider));
-		}
+            AddProvider("System.Data.SqlClient", typeof(SqlProvider));
+            AddProvider("System.Data.OracleClient", typeof(OracleProvider));
+            AddProvider("MySql.Data.MySqlClient", typeof(MySqlProvider));
+        }
 
-		public IDataProvider Create(ConnectionStringSettings settings, Transaction transactionMode)
-		{
-			var provider = ResolveDataProvider(settings.ProviderName);
-			provider.DbConnection = CreateConnection(settings.ProviderName, settings);
-			provider.TransactionMode = transactionMode;
-			return provider;
-		}
+        public IDataProvider Create(ConnectionStringSettings settings, Transaction transactionMode)
+        {
+            var provider = ResolveDataProvider(settings.ProviderName);
+            provider.DbConnection = CreateConnection(settings.ProviderName, settings);
+            provider.TransactionMode = transactionMode;
+            return provider;
+        }
 
-		public IDataProvider ResolveDataProvider(string providerName)
-		{
-			if (CustomProvider != null) return CustomProvider(providerName);
+        public IDataProvider ResolveDataProvider(string providerName)
+        {
+            if (CustomProvider != null) return CustomProvider(providerName);
 
-			if (Providers.ContainsKey(providerName))
-			{
-				return (IDataProvider)Activator.CreateInstance(Providers[providerName]);
-			}
+            if (Providers.ContainsKey(providerName))
+            {
+                return (IDataProvider)Activator.CreateInstance(Providers[providerName]);
+            }
 
-			var exceptionMessage = String.Format(
-				"Thunderstruck do not supports the '{0}' provider. Either add your provider using the ProviderFactory.AddProvider() method, or create and set a ProviderResolver.CustomProvider.",
-				providerName);
+            var exceptionMessage = String.Format(
+                "Thunderstruck do not supports the '{0}' provider. Either add your provider using the ProviderFactory.AddProvider() method, or create and set a ProviderResolver.CustomProvider.",
+                providerName);
 
-			throw new ThunderException(exceptionMessage);
-		}
+            throw new ThunderException(exceptionMessage);
+        }
 
-		private IDbConnection CreateConnection(string providerName, ConnectionStringSettings settings)
-		{
-			IDbConnection connection;
+        private IDbConnection CreateConnection(string providerName, ConnectionStringSettings settings)
+        {
+            IDbConnection connection;
 
-			if (ConnectionFactory != null) connection = ConnectionFactory(providerName);
-			else connection = DbProviderFactories.GetFactory(providerName).CreateConnection();
+            if (ConnectionFactory != null) connection = ConnectionFactory(providerName);
+            else connection = DbProviderFactories.GetFactory(providerName).CreateConnection();
 
-			connection.ConnectionString = settings.ConnectionString;
+            connection.ConnectionString = settings.ConnectionString;
 
-			return connection;
-		}
+            return connection;
+        }
 
-		public static void AddProvider(string providerName, Type providerType)
-		{
-			if (String.IsNullOrWhiteSpace(providerName))
-			{
-				throw new ArgumentException("Parameter 'providerName' can not be null and must contain data.", "providerName");
-			}
-			if (providerType == null)
-			{
-				throw new ArgumentNullException("providerType");
-			}
-			if (Providers.ContainsKey(providerName))
-			{
-				if (!Providers[providerName].Equals(providerType))
-				{
-					var message = String.Format(
-						"Attempting to add a provider named '{0}' of type '{1}', but an existing provider of type '{2}' already exists with that name.",
-						providerName, providerType.ToString(), Providers[providerName].ToString());
+        public static void AddProvider(string providerName, Type providerType)
+        {
+            if (String.IsNullOrWhiteSpace(providerName))
+            {
+                throw new ArgumentException("Parameter 'providerName' can not be null and must contain data.", "providerName");
+            }
+            if (providerType == null)
+            {
+                throw new ArgumentNullException("providerType");
+            }
+            if (Providers.ContainsKey(providerName))
+            {
+                if (!Providers[providerName].Equals(providerType))
+                {
+                    var message = String.Format(
+                        "Attempting to add a provider named '{0}' of type '{1}', but an existing provider of type '{2}' already exists with that name.",
+                        providerName, providerType.ToString(), Providers[providerName].ToString());
 
-					throw new ThunderException(message);
-				}
-			}
-			else
-			{
-				Providers.Add(providerName, providerType);
-			}
-		}
-	}
+                    throw new ThunderException(message);
+                }
+            }
+            else
+            {
+                Providers.Add(providerName, providerType);
+            }
+        }
+    }
 }

--- a/Thunderstruck/Provider/ProviderFactory.cs
+++ b/Thunderstruck/Provider/ProviderFactory.cs
@@ -1,52 +1,78 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using Thunderstruck.Provider.Common;
 
 namespace Thunderstruck.Provider
 {
-    public class ProviderFactory
-    {
-        public static Func<string, IDataProvider> CustomProvider { get; set; }
+	public class ProviderFactory
+	{
+		public static Func<string, IDataProvider> CustomProvider { get; set; }
 
-        public static Func<string, IDbConnection> ConnectionFactory { get; set; }
+		public static Func<string, IDbConnection> ConnectionFactory { get; set; }
 
-        public IDataProvider Create(ConnectionStringSettings settings, Transaction transactionMode)
-        {
-            var provider = ResolveDataProvider(settings.ProviderName);
-            provider.DbConnection = CreateConnection(settings.ProviderName, settings);
-            provider.TransactionMode = transactionMode;
-            return provider;
-        }
+		private static Dictionary<string, Type> Providers;
 
-        public IDataProvider ResolveDataProvider(string providerName)
-        {
-            if (CustomProvider != null) return CustomProvider(providerName);
+		static ProviderFactory()
+		{
+			Providers = new Dictionary<string, Type>();
 
-            switch (providerName)
-            {
-                case "System.Data.SqlClient": return new SqlProvider();
-                case "System.Data.OracleClient": return new OracleProvider();
-                case "MySql.Data.MySqlClient": return new MySqlProvider();
-                default:
-                    var exceptionMessage = String.Concat(
-                        "Thunderstruck do not supports the '", providerName,
-                        "' provider. Try create and set a ProviderResolver.CustomProvider, it is easy.");
-                    throw new ThunderException(exceptionMessage);
-            }
-        }
+			AddProvider("System.Data.SqlClient", typeof(SqlProvider));
+			AddProvider("System.Data.OracleClient", typeof(OracleProvider));
+			AddProvider("MySql.Data.MySqlClient", typeof(MySqlProvider));
+		}
 
-        private IDbConnection CreateConnection(string providerName, ConnectionStringSettings settings)
-        {
-            IDbConnection connection;
+		public IDataProvider Create(ConnectionStringSettings settings, Transaction transactionMode)
+		{
+			var provider = ResolveDataProvider(settings.ProviderName);
+			provider.DbConnection = CreateConnection(settings.ProviderName, settings);
+			provider.TransactionMode = transactionMode;
+			return provider;
+		}
 
-            if (ConnectionFactory != null) connection = ConnectionFactory(providerName);
-            else connection = DbProviderFactories.GetFactory(providerName).CreateConnection();
+		public IDataProvider ResolveDataProvider(string providerName)
+		{
+			if (CustomProvider != null) return CustomProvider(providerName);
 
-            connection.ConnectionString = settings.ConnectionString;
+			if (Providers.ContainsKey(providerName))
+			{
+				return (IDataProvider)Activator.CreateInstance(Providers[providerName]);
+			}
 
-            return connection;
-        }
-    }
+			var exceptionMessage = String.Format(
+				"Thunderstruck do not supports the '{0}' provider. Either add your provider using the ProviderFactory.AddProvider() method, or create and set a ProviderResolver.CustomProvider.",
+				providerName);
+		
+			throw new ThunderException(exceptionMessage);
+		}
+
+		private IDbConnection CreateConnection(string providerName, ConnectionStringSettings settings)
+		{
+			IDbConnection connection;
+
+			if (ConnectionFactory != null) connection = ConnectionFactory(providerName);
+			else connection = DbProviderFactories.GetFactory(providerName).CreateConnection();
+
+			connection.ConnectionString = settings.ConnectionString;
+
+			return connection;
+		}
+
+		public static void AddProvider(string providerName, Type providerType)
+		{
+			if (String.IsNullOrWhiteSpace(providerName))
+			{
+				throw new ArgumentException("Parameter 'providerName' can not be null and must contain data.", "providerName");
+			}
+			if (providerType == null)
+			{
+				throw new ArgumentNullException("providerType");
+			}
+
+			Providers.Add(providerName, providerType);
+		}
+	}
 }

--- a/Thunderstruck/Runtime/DataReader.cs
+++ b/Thunderstruck/Runtime/DataReader.cs
@@ -1,103 +1,130 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Dynamic;
 using System.Linq;
+using System.Reflection;
 
 namespace Thunderstruck.Runtime
 {
-    public class DataReader
-    {
-        private readonly IDataReader _dataReader;
+	public class DataReader
+	{
+		private readonly IDataReader _dataReader;
 
-        public DataReader(IDataReader dataReader)
-        {
-            _dataReader = dataReader;
-        }
+		public DataReader(IDataReader dataReader)
+		{
+			_dataReader = dataReader;
+		}
 
-        public IEnumerable<T> ToObjectList<T>() where T : new()
-        {
-            try
-            {
-                var list = new List<T>();
-                var properties = typeof(T).GetProperties();
-                var readerFields = GetFields();
+		public IEnumerable<T> ToObjectList<T>() where T : new()
+		{
+			try
+			{
+				var list = new List<T>();
+				var properties = typeof(T).GetProperties();
+				var readerFields = GetFields();
 
-                while (_dataReader.Read())
-                {
-                    var item = new T();
+				bool isDynamic = (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(typeof(T)));
+				IDictionary<string, object> dynamicValues = null;
 
-                    foreach (var field in readerFields)
-                    {
-                        var property = properties.FirstOrDefault(p => p.Name.ToUpper() == field.ToUpper());
-                        if (property == null || !property.CanWrite) continue;
+				while (_dataReader.Read())
+				{
+					var item = new T();
 
-                        try
-                        {
-                            var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
-                            object safeValue = null;
-                            if (property.PropertyType.IsEnum)
-                            {
-                                var enumType = property.PropertyType;
-                                var enumValue = Convert.ToInt32(_dataReader[field].ToString());
-                                safeValue = Enum.ToObject(enumType, enumValue);
-                            }
-                            else
-                            {
-                                var isNull = _dataReader[field] == null || _dataReader[field] is DBNull;
-                                safeValue = (isNull) ? null : Convert.ChangeType(_dataReader[field], propertyType);
-                            }
-                            var stringSafeValue = safeValue as String;
-                            if (stringSafeValue != null) safeValue = stringSafeValue.Trim();
-                            property.SetValue(item, safeValue, null);
-                        }
-                        catch (FormatException err)
-                        {
-                            var message = String.Format("Error to convert column {0} to property {1} {2}.{3}",
-                                property.Name, property.PropertyType.Name, typeof(T).Name, property.Name);
+					foreach (var field in readerFields)
+					{
+						if (isDynamic)
+						{
+							if (dynamicValues == null)
+							{
+								dynamicValues = (IDictionary<string, object>)item;
+							}
 
-                            throw new FormatException(message, err);
-                        }
-                    }
+							dynamicValues[field] = GetSafeValue(_dataReader[field].GetType(), field);
 
-                    list.Add(item);
-                }
+							continue;
+						}
 
-                return list;
-            }
-            finally
-            {
-                _dataReader.Close();
-            }
-        }
+						var property = properties.FirstOrDefault(p => p.Name.ToUpper() == field.ToUpper());
+						if (property == null || !property.CanWrite) continue;
 
-        public IEnumerable<T> ToEnumerable<T>()
-        {
-            try
-            {
-                var list = new List<T>();
-                while (_dataReader.Read())
-                {
-                    list.Add(CastTo<T>(_dataReader[0]));
-                }
-                return list;
-            }
-            finally
-            {
-                _dataReader.Close();
-            }
-        }
+						try
+						{
+							var safeValue = GetSafeValue(Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType, field);
+							property.SetValue(item, safeValue, null);
+						}
+						catch (FormatException err)
+						{
+							var message = String.Format("Error to convert column {0} to property {1} {2}.{3}",
+								property.Name, property.PropertyType.Name, typeof(T).Name, property.Name);
 
-        public string[] GetFields()
-        {
-            var fields = new String[_dataReader.FieldCount];
-            for (int i = 0; i < _dataReader.FieldCount; i++) fields[i] = _dataReader.GetName(i);
-            return fields;
-        }
+							throw new FormatException(message, err);
+						}
+					}
 
-        public static T CastTo<T>(object value)
-        {
-            if (value is DBNull) return default(T);
-            return (T) Convert.ChangeType(value, typeof(T));
-        }
-    }
+					list.Add(item);
+				}
+
+				return list;
+			}
+			finally
+			{
+				_dataReader.Close();
+			}
+		}
+
+		private object GetSafeValue(Type propertyType, string field)
+		{
+			object safeValue = null;
+
+			if (propertyType.IsEnum)
+			{
+				var enumValue = Convert.ToInt32(_dataReader[field].ToString());
+				safeValue = Enum.ToObject(propertyType, enumValue);
+			}
+			else
+			{
+				var isNull = _dataReader[field] == null || _dataReader[field] is DBNull;
+				safeValue = (isNull) ? null : Convert.ChangeType(_dataReader[field], propertyType);
+			}
+
+			var stringSafeValue = safeValue as String;
+			if (stringSafeValue != null)
+			{
+				safeValue = stringSafeValue.Trim();
+			}
+
+			return safeValue;
+		}
+
+		public IEnumerable<T> ToEnumerable<T>()
+		{
+			try
+			{
+				var list = new List<T>();
+				while (_dataReader.Read())
+				{
+					list.Add(CastTo<T>(_dataReader[0]));
+				}
+				return list;
+			}
+			finally
+			{
+				_dataReader.Close();
+			}
+		}
+
+		public string[] GetFields()
+		{
+			var fields = new String[_dataReader.FieldCount];
+			for (int i = 0; i < _dataReader.FieldCount; i++) fields[i] = _dataReader.GetName(i);
+			return fields;
+		}
+
+		public static T CastTo<T>(object value)
+		{
+			if (value is DBNull) return default(T);
+			return (T)Convert.ChangeType(value, typeof(T));
+		}
+	}
 }

--- a/Thunderstruck/Runtime/DataReader.cs
+++ b/Thunderstruck/Runtime/DataReader.cs
@@ -7,124 +7,124 @@ using System.Reflection;
 
 namespace Thunderstruck.Runtime
 {
-	public class DataReader
-	{
-		private readonly IDataReader _dataReader;
+    public class DataReader
+    {
+        private readonly IDataReader _dataReader;
 
-		public DataReader(IDataReader dataReader)
-		{
-			_dataReader = dataReader;
-		}
+        public DataReader(IDataReader dataReader)
+        {
+            _dataReader = dataReader;
+        }
 
-		public IEnumerable<T> ToObjectList<T>() where T : new()
-		{
-			try
-			{
-				var list = new List<T>();
-				var properties = typeof(T).GetProperties();
-				var readerFields = GetFields();
+        public IEnumerable<T> ToObjectList<T>() where T : new()
+        {
+            try
+            {
+                var list = new List<T>();
+                var properties = typeof(T).GetProperties();
+                var readerFields = GetFields();
 
-				bool isDynamic = (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(typeof(T)));
-				IDictionary<string, object> dynamicValues = null;
+                bool isDynamic = (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(typeof(T)));
+                IDictionary<string, object> dynamicValues = null;
 
-				while (_dataReader.Read())
-				{
-					var item = new T();
+                while (_dataReader.Read())
+                {
+                    var item = new T();
 
-					foreach (var field in readerFields)
-					{
-						if (isDynamic)
-						{
-							if (dynamicValues == null)
-							{
-								dynamicValues = (IDictionary<string, object>)item;
-							}
+                    foreach (var field in readerFields)
+                    {
+                        if (isDynamic)
+                        {
+                            if (dynamicValues == null)
+                            {
+                                dynamicValues = (IDictionary<string, object>)item;
+                            }
 
-							dynamicValues[field] = GetSafeValue(_dataReader[field].GetType(), field);
+                            dynamicValues[field] = GetSafeValue(_dataReader[field].GetType(), field);
 
-							continue;
-						}
+                            continue;
+                        }
 
-						var property = properties.FirstOrDefault(p => p.Name.ToUpper() == field.ToUpper());
-						if (property == null || !property.CanWrite) continue;
+                        var property = properties.FirstOrDefault(p => p.Name.ToUpper() == field.ToUpper());
+                        if (property == null || !property.CanWrite) continue;
 
-						try
-						{
-							var safeValue = GetSafeValue(Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType, field);
-							property.SetValue(item, safeValue, null);
-						}
-						catch (FormatException err)
-						{
-							var message = String.Format("Error to convert column {0} to property {1} {2}.{3}",
-								property.Name, property.PropertyType.Name, typeof(T).Name, property.Name);
+                        try
+                        {
+                            var safeValue = GetSafeValue(Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType, field);
+                            property.SetValue(item, safeValue, null);
+                        }
+                        catch (FormatException err)
+                        {
+                            var message = String.Format("Error to convert column {0} to property {1} {2}.{3}",
+                                property.Name, property.PropertyType.Name, typeof(T).Name, property.Name);
 
-							throw new FormatException(message, err);
-						}
-					}
+                            throw new FormatException(message, err);
+                        }
+                    }
 
-					list.Add(item);
-				}
+                    list.Add(item);
+                }
 
-				return list;
-			}
-			finally
-			{
-				_dataReader.Close();
-			}
-		}
+                return list;
+            }
+            finally
+            {
+                _dataReader.Close();
+            }
+        }
 
-		private object GetSafeValue(Type propertyType, string field)
-		{
-			object safeValue = null;
+        private object GetSafeValue(Type propertyType, string field)
+        {
+            object safeValue = null;
 
-			if (propertyType.IsEnum)
-			{
-				var enumValue = Convert.ToInt32(_dataReader[field].ToString());
-				safeValue = Enum.ToObject(propertyType, enumValue);
-			}
-			else
-			{
-				var isNull = _dataReader[field] == null || _dataReader[field] is DBNull;
-				safeValue = (isNull) ? null : Convert.ChangeType(_dataReader[field], propertyType);
-			}
+            if (propertyType.IsEnum)
+            {
+                var enumValue = Convert.ToInt32(_dataReader[field].ToString());
+                safeValue = Enum.ToObject(propertyType, enumValue);
+            }
+            else
+            {
+                var isNull = _dataReader[field] == null || _dataReader[field] is DBNull;
+                safeValue = (isNull) ? null : Convert.ChangeType(_dataReader[field], propertyType);
+            }
 
-			var stringSafeValue = safeValue as String;
-			if (stringSafeValue != null)
-			{
-				safeValue = stringSafeValue.Trim();
-			}
+            var stringSafeValue = safeValue as String;
+            if (stringSafeValue != null)
+            {
+                safeValue = stringSafeValue.Trim();
+            }
 
-			return safeValue;
-		}
+            return safeValue;
+        }
 
-		public IEnumerable<T> ToEnumerable<T>()
-		{
-			try
-			{
-				var list = new List<T>();
-				while (_dataReader.Read())
-				{
-					list.Add(CastTo<T>(_dataReader[0]));
-				}
-				return list;
-			}
-			finally
-			{
-				_dataReader.Close();
-			}
-		}
+        public IEnumerable<T> ToEnumerable<T>()
+        {
+            try
+            {
+                var list = new List<T>();
+                while (_dataReader.Read())
+                {
+                    list.Add(CastTo<T>(_dataReader[0]));
+                }
+                return list;
+            }
+            finally
+            {
+                _dataReader.Close();
+            }
+        }
 
-		public string[] GetFields()
-		{
-			var fields = new String[_dataReader.FieldCount];
-			for (int i = 0; i < _dataReader.FieldCount; i++) fields[i] = _dataReader.GetName(i);
-			return fields;
-		}
+        public string[] GetFields()
+        {
+            var fields = new String[_dataReader.FieldCount];
+            for (int i = 0; i < _dataReader.FieldCount; i++) fields[i] = _dataReader.GetName(i);
+            return fields;
+        }
 
-		public static T CastTo<T>(object value)
-		{
-			if (value is DBNull) return default(T);
-			return (T)Convert.ChangeType(value, typeof(T));
-		}
-	}
+        public static T CastTo<T>(object value)
+        {
+            if (value is DBNull) return default(T);
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+    }
 }

--- a/Thunderstruck/Thunderstruck.nuspec
+++ b/Thunderstruck/Thunderstruck.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Thunderstruck</id>
-    <version>0.2.3</version>
+    <version>0.2.4</version>
     <title>Thunderstruck</title>
     <authors>Wagner Andrade</authors>
     <owners>Wagner Andrade</owners>

--- a/Thunderstruck/Thunderstruck.nuspec
+++ b/Thunderstruck/Thunderstruck.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Thunderstruck</id>
-    <version>0.2.2</version>
+    <version>0.2.3</version>
     <title>Thunderstruck</title>
     <authors>Wagner Andrade</authors>
     <owners>Wagner Andrade</owners>


### PR DESCRIPTION
I've added some better support for custom providers, and dynamic objects.

Problem 1: In the current version, if you implement a ProviderFactory.CustomProvider, all the default providers are ignored. 
Problem 2: No support for returning dynamic objects from DataContext calls.

This refactor has NON-BREAKING CHANGES. The existing CustomProvider works as-is. Instead, all out-of-the-box providers, and any additional providers, are added using a ProviderFactory.AddProvider() method. These are stored in a dictionary, so when instantiating a provider, the dictionary is looked up to find the appropriate provider.

As for dynamic support, it is also non-breaking. Request a dynamic object, and get one back. Simple as that.

All existing unit tests pass, and a new one to test the new functionality also passes. Readme file is updated (I also fixed a few technical and grammatical errors).

Also, incremented the version number to 0.2.4.